### PR TITLE
Old style exception to new style.

### DIFF
--- a/pyrebox/third_party/panda/pmemaddressspace.py
+++ b/pyrebox/third_party/panda/pmemaddressspace.py
@@ -95,7 +95,7 @@ class PMemAddressSpace(addrspace.BaseAddressSpace):
             if result is None:
                 raise AssertionError("PMemAddressSpace: WRITE of length " + str(length) +
                                      " @ " + hex(addr) + " failed.")
-        except AssertionError, e:
+        except AssertionError as e:
             print(e)
             return False
         return True


### PR DESCRIPTION
flake8 testing of https://github.com/Cisco-Talos/pyrebox on Python 3.6.2

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./pyrebox/third_party/panda/pmemaddressspace.py:98:30: E999 SyntaxError: invalid syntax
        except AssertionError, e:
                             ^
```