### PR TITLE
Allow custom config files.

### DIFF
--- a/pyrebox/init.py
+++ b/pyrebox/init.py
@@ -211,7 +211,7 @@ def init_volatility():
         return False
 
 
-def init(platform, root_path, volatility_path):
+def init(platform, root_path, volatility_path, conf_name):
     try:
         # Just configure basic logging
         import logging
@@ -219,16 +219,16 @@ def init(platform, root_path, volatility_path):
         # Initialize stuff
         pp_debug("[*] Platform: %s\n" % platform)
         pp_debug("[*] Starting python module initialization\n")
-        pp_debug("[*] Reading configuration\n")
+        pp_debug("[*] Reading configuration from '%s'\n" % (conf_name))
         sys.settrace
         config = ConfigParser.RawConfigParser()
         # Store configuration information in raw,
         # for plugins to be able to fetch it
         conf_m.config = config
-        if not os.path.isfile("pyrebox.conf"):
-            pp_error("[!] Could not initialize pyrebox, pyrebox.conf file missing!\n")
+        if not os.path.isfile(conf_name):
+            pp_error("[!] Could not initialize pyrebox, conf file '%s' missing!\n" % (conf_name))
             return None
-        config.read('pyrebox.conf')
+        config.read(conf_name)
         vol_profile = config.get('VOL', 'profile')
         # Set global configuration
         conf_m.volatility_path = volatility_path

--- a/pyrebox/pyrebox.c
+++ b/pyrebox/pyrebox.c
@@ -55,7 +55,7 @@ void clear_targets(void){
   clear_monitored_processes();
 }
 
-int pyrebox_init(void){
+int pyrebox_init(const char *pyrebox_conf_str){
 
   //Initialize mutex to call python code, which may sometime be thread unsafe
   if (pthread_mutex_init(&pyrebox_mutex, NULL) != 0){      
@@ -121,11 +121,13 @@ int pyrebox_init(void){
   PyObject *platform_str = PyString_FromString(target_platform);
   PyObject *root_path_str = PyString_FromString(ROOT_PATH);
   PyObject *volatility_path_str = PyString_FromString(VOLATILITY_PATH);
+  PyObject *conf_name_str = PyString_FromString(pyrebox_conf_str);
 
-  py_args_tuple = PyTuple_New(3);
+  py_args_tuple = PyTuple_New(4);
   PyTuple_SetItem(py_args_tuple, 0, platform_str); 
   PyTuple_SetItem(py_args_tuple, 1, root_path_str); 
   PyTuple_SetItem(py_args_tuple, 2, volatility_path_str); 
+  PyTuple_SetItem(py_args_tuple, 3, conf_name_str);
 
   py_init = PyDict_GetItemString(py_global_dict, "init");
   PyObject* vol_profile = PyObject_CallObject(py_init,py_args_tuple);

--- a/pyrebox/pyrebox.h
+++ b/pyrebox/pyrebox.h
@@ -27,6 +27,6 @@
 extern pthread_mutex_t pyrebox_mutex;
 
 void clear_targets(void);
-int pyrebox_init(void);
+int pyrebox_init(const char *pyrebox_conf_str);
 int pyrebox_finalize(void);
 #endif

--- a/qemu/qemu-options.hx
+++ b/qemu/qemu-options.hx
@@ -11,6 +11,15 @@ STEXI
 @table @option
 ETEXI
 
+DEF("conf", HAS_ARG, QEMU_OPTION_conf, \
+    "-conf custom.conf\n"
+    "                PyREBox Config File. Default: pyrebox.conf\n", QEMU_ARCH_ALL)
+STEXI
+@item -conf
+@findex -conf
+Load this config file rather than pyrebox.conf
+ETEXI
+
 DEF("help", 0, QEMU_OPTION_h,
     "-h or -help     display this help and exit\n", QEMU_ARCH_ALL)
 STEXI

--- a/qemu/vl.c
+++ b/qemu/vl.c
@@ -2995,9 +2995,6 @@ static void register_global_properties(MachineState *ms)
 
 int main(int argc, char **argv, char **envp)
 {
-    if (pyrebox_init()){
-        return 1;
-    }
     int i;
     int snapshot, linux_boot;
     const char *initrd_filename;
@@ -3033,6 +3030,7 @@ int main(int argc, char **argv, char **envp)
     Error *main_loop_err = NULL;
     Error *err = NULL;
     bool list_data_dirs = false;
+    const char *pyrebox_conf_name = "pyrebox.conf";
     typedef struct BlockdevOptions_queue {
         BlockdevOptions *bdo;
         Location loc;
@@ -3119,6 +3117,9 @@ int main(int argc, char **argv, char **envp)
 
             popt = lookup_opt(argc, argv, &optarg, &optind);
             switch (popt->index) {
+            case QEMU_OPTION_conf:
+	        pyrebox_conf_name = optarg;
+                break; 
             case QEMU_OPTION_nodefconfig:
                 defconfig = false;
                 break;
@@ -3127,6 +3128,10 @@ int main(int argc, char **argv, char **envp)
                 break;
             }
         }
+    }
+
+    if (pyrebox_init(pyrebox_conf_name)){
+        return 1;
     }
 
     if (defconfig && userconfig) {


### PR DESCRIPTION
Added `-conf` option to qemu which allows for a custom config file.

Originally, `pyrebox.conf` in the working folder was hard-coded. This has been replaced with a variable provided by a command line option, but leaves `pyrebox.conf`in the working folder as the default if the option is not provided.

The value provided to the option can be relative or absolute.

```
btg@box ~/pyrebox $ ./pyrebox-i386 -conf btg.conf -drive file=Win7SP1x86.qcow2 -monitor stdio
```

The debug logging has also been updated to report which config file is being loaded.