### PR TITLE
Block end callback fixes

### DIFF
--- a/qemu/target/i386/translate.c
+++ b/qemu/target/i386/translate.c
@@ -2617,6 +2617,20 @@ do_gen_eob_worker(DisasContext *s, bool inhibit, bool recheck_tf, TCGv jr)
         TCGv vaddr = tcg_temp_new();
 
         tcg_gen_add_tl(vaddr, jr, cpu_seg_base[R_CS]);
+
+        //Pyrebox: block_end
+        //helper_qemu_block_end_callback(CPUState* cpu,TranslationBlock* next_tb, target_ulong from)
+        if (is_block_end_callback_needed(s->pgd)){
+            TCGv_ptr tcg_tb = tcg_const_ptr((tcg_target_ulong)s->tb);
+            TCGv tcg_from = tcg_temp_new();
+            tcg_gen_movi_tl(tcg_from, s->saved_pc);
+            TCGv_ptr tcg_cpu = tcg_const_ptr((tcg_target_ulong)s->cs);
+            gen_helper_qemu_block_end_callback(tcg_cpu,tcg_tb,tcg_from,jr);
+            tcg_temp_free(tcg_from);
+            tcg_temp_free_ptr(tcg_tb);
+            tcg_temp_free_ptr(tcg_cpu);
+        }
+
         tcg_gen_lookup_and_goto_ptr(vaddr);
         tcg_temp_free(vaddr);
     } else {


### PR DESCRIPTION
P1
First part of this patch adds missing block end callback for indirect jump instructions.
The `} else if (!TCGV_IS_UNUSED(jr)) {` condition seems to be true when qemu translates jump to virtual register (indirect jumps/calls and even ret instructions).
Without this addition, callback was not triggered for such instructions.


P2
Second part tries to address issues with basic block ends being only subset of translation block ends.
Under certain conditions, like too long basic block or popf, sti, invlpg instructions, TB translation is terminated immediately even though basic block didn't end.
There could be some cases missing, but this still saves a lot of time and effort in scripts checking / disassembling `prev_pc`.

Alternative: documentation could be updated to reflect, that the callback triggers on translation block end and that basic block end checking can be done through multiple INSN_END_CB callbacks.