### PR TITLE
Add more control to the windows agent process creation

### DIFF
--- a/guest/win/guest_agent.c
+++ b/guest/win/guest_agent.c
@@ -112,9 +112,27 @@ int exec_file(){
 
     /* Use Windows API CreateProcess because unlike execv* or fork(), 
      * allows the parent to exit while the child keeps running */
-    STARTUPINFO si;
-    PROCESS_INFORMATION pi;
-    CreateProcess(path,args,0,0,0,0,env,0,&si,&pi);
+    STARTUPINFO si = {};
+    PROCESS_INFORMATION pi = {};
+
+    si.cb = sizeof(si);
+    if( ! CreateProcess( (path[0]) ? path : NULL, // lpApplicationName
+                         (args[0]) ? args : NULL, // lpCommandLine
+                         0,    // lpProcessAttributes
+                         0,    // lpThreadAttributes
+                         0,    // bInheritHandles
+                         0,    // dwCreationFlags
+                         (env[0]) ? env : NULL,
+                         0,    // lpCurrentDirectory
+                         &si,  // lpStartupInfo
+                         &pi   // lpProcessInformation
+                       ) ){
+        fprintf(stderr, "The process creation failed %d under Pyrebox.\n", GetLastError());
+    }
+    else {
+        CloseHandle(pi.hProcess);
+        CloseHandle(pi.hThread);
+    }
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
- Initialize PROCESS_INFORMATION to zero
- Initialize STARTUPINFO to zero, set si.cb
- Add error message printing if process creation fails
- Clean up handles if process creation was successful
- Pass NULL instead of zero length strings (a zero length string string for the environment means no environment is present for the created process)