### PR TITLE
mw_monitor: win7 _EX_FAST_REF -> FileObject

### DIFF
--- a/mw_monitor/interproc.py
+++ b/mw_monitor/interproc.py
@@ -332,7 +332,7 @@ def ntopenprocessret(cpu_index, cpu, pid, callback_name, proc_hdl_p, proc, updat
                 return
         new_proc = Process(str(proc_obj.ImageFileName))
         new_proc.set_pid(int(proc_obj.UniqueProcessId))
-        new_proc.set_cr3(int(proc_obj.Pcb.DirectoryTableBase.v()))
+        new_proc.set_pgd(int(proc_obj.Pcb.DirectoryTableBase.v()))
         mw_monitor_start_monitoring_process(new_proc)
     else:
         if TARGET_LONG_SIZE == 4: 

--- a/mw_monitor/mw_monitor_classes.py
+++ b/mw_monitor/mw_monitor_classes.py
@@ -1064,6 +1064,16 @@ class Section:
                 "_SEGMENT")
             file_obj = self.segment.ControlArea.FilePointer
 
+            from volatility.plugins.overlays.windows.windows import _FILE_OBJECT
+            if type(file_obj) is not _FILE_OBJECT:
+                from volatility.plugins.overlays.windows.windows import _EX_FAST_REF
+                if type(file_obj) is _EX_FAST_REF:
+                    # on newer volatility profiles, FilePointer is _EX_FAST_REF, needs deref
+                    file_obj = file_obj.dereference_as("_FILE_OBJECT")
+                else:
+                    raise TypeError("The type for self.segment.ControlArea.FilePointer in Section" + \
+                                    "class does not match _FILE_OBJECT or _EX_FAST_REF")
+
             for fi in mwmon.data.files:
                 if fi.file_name == str(file_obj.FileName):
                     self.backing_file = fi

--- a/mw_monitor/mw_monitor_classes.py
+++ b/mw_monitor/mw_monitor_classes.py
@@ -685,7 +685,7 @@ class Process:
         # Check if we can remove the module from the list of modules with
         # pending symbol resolution
         for mod in api.get_module_list(self.get_pgd()):
-            if mod["symbols_resolved"] and mod["name"] in mods_pending_symbol_resolution[self.get_pgd()]:
+            if mod["symbols_resolved"] and mod["name"] in mods_pending_symbol_resolution.get(self.get_pgd(), []):
                 del mods_pending_symbol_resolution[self.get_pgd()][mod["name"]]
 
         for d in syms:


### PR DESCRIPTION
Ran into problems when trying mw_monitor on win7 sp1 x86.

Looks like the volatility ControlArea struct has _EX_FAST_REF for FilePointer now instead of FileObject.