### PR TITLE
RHEL/Fedora Equivalent Dependencies

### DIFF
--- a/BUILD.rst
+++ b/BUILD.rst
@@ -7,6 +7,10 @@ Building PyREBox
       
     ``apt-get install build-essential zlib1g-dev pkg-config libglib2.0-dev binutils-dev libboost-all-dev autoconf libtool libssl-dev libpixman-1-dev libpython-dev python-pip virtualenv python-capstone``
 
+  * For RHEL based distributions: 
+      
+    ``dnf install make automake gcc gcc-c++ kernel-devel zlib-devel pkgconf-pkg-config glib2-devel binutils-devel boost-devel autoconf libtool openssl-devel pixman-devel python2-devel python2-pip python2-virtualenv capstone-python``
+
   * Required python packages (see the next paragraph for installation instructions):
       
     ``ipython>=5,<6 sphinx sphinx-autobuild prettytable pefile capstone distorm3 pycrypto pytz``


### PR DESCRIPTION
For anyone who would like to install the RHEL/Fedora equivalent dependencies.

**NOTE:** If one runs into the problem where running ``./build.sh`` shows Qemu's ``./configure`` saying
"ERROR: "cc" either does not exist or does not work"
it's because of permission conflicts as ``cc`` builds output files to ``~/.ccache/4/9`` (as it is owned by root). 

I gave it the benefit of the doubt that I don't have all the dependencies and did the following:

``sudo dnf install qemu``
^Installs literally everything it needs. Downside, you have 500M worth of qemu stuff on your system.
``sudo ./build.sh``
^Yeah not the greatest idea, but hey it worked. 

Not sure how that information can be added to the BUILD. So, I'll leave it to you.