### PR TITLE
[docs] Quickstart - Mouse pointer synchronization

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -92,6 +92,10 @@ Enable usb support
 ::
   -usb
 
+If the host(local) mouse pointer isn't properly synchronized with guest(remote) mouse pointer, add
+::
+  -device usb-tablet
+
 You can specify main image file with unsafe caching. Unsafe caching will make snapshoting much faster
 ::
   -drive file=images/xpsp3.qcow,index=0,media=disk,format=qcow2,cache=unsafe


### PR DESCRIPTION
Qemu option to properly synchronize local with remote mouse pointer. Without this option in VNCViewer(4.1.1) the pointers are desynchronized.