### PR TITLE
Fix Dockerfile build error by upgrading pip version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ RUN apt-get install -y build-essential zlib1g-dev pkg-config \
                        libpython-dev python-pip \
                        git curl vim
 
+#upgrade pip
+RUN pip install --upgrade pip
+
 #clone pybox
 RUN git clone https://github.com/Cisco-Talos/pyrebox pyrebox
 WORKDIR pyrebox


### PR DESCRIPTION
This pull request fixes Dockerfile build error. Upgrading pip version before clone, the image is correctly built.