### PR TITLE
Correct if  in mw_monitor_class

### DIFF
--- a/mw_monitor/mw_monitor_classes.py
+++ b/mw_monitor/mw_monitor_classes.py
@@ -174,7 +174,7 @@ def find_ep(proc, proc_name):
             name = m["name"]
             base = m["base"]
             # size = m["size"]
-            if name == proc_name:
+            if proc_name in name:
                     pe_data = api.r_va(proc.get_pgd(), base, 0x1000)
                     pe = pefile.PE(data=pe_data)
                     ep = pe.OPTIONAL_HEADER.AddressOfEntryPoint


### PR DESCRIPTION
compares two strings of different size because volatility only uses 8 characters 