### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN apt-get install -y build-essential zlib1g-dev pkg-config \
                        git curl vim
 
 #upgrade pip
-RUN pip install --upgrade pip
+# RUN pip install --upgrade pip
+RUN python -m pip install pip==20.3
 
 #clone pybox
 RUN git clone https://github.com/Cisco-Talos/pyrebox pyrebox


### PR DESCRIPTION
python version in Dockerfile is 2.7, so "pip install --upgrade pip" will fail because last version of pip is not compatible with python2 (see https://pypi.org/project/pip/); so an older version of pip must be used, like 20.3